### PR TITLE
Enhance TwilioHelper for election context handling

### DIFF
--- a/Site/CoreModels/Helper/OnlineVoterOtherInfo.cs
+++ b/Site/CoreModels/Helper/OnlineVoterOtherInfo.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace TallyJ.CoreModels.Helper
+{
+	public class OnlineVoterOtherInfo
+	{
+		[JsonProperty("numEl")]
+    public int NumElections { get; set; }
+	}
+}

--- a/Site/CoreModels/Helper/TwilioHelper.cs
+++ b/Site/CoreModels/Helper/TwilioHelper.cs
@@ -39,7 +39,7 @@ namespace TallyJ.CoreModels.Helper
     //  return ok;
     //}
 
-    public bool SendVerifyCodeToVoter(string phone, string newCode, string method, string hubKey, out string error)
+    public bool SendVerifyCodeToVoter(string phone, string newCode, string method, string hubKey, bool isInElection, out string error)
     {
       var text = GetSmsTemplate("VerifyCodeSms").FilledWithObject(new
       {
@@ -48,7 +48,7 @@ namespace TallyJ.CoreModels.Helper
 
       // this voter is not in a specific election...
 
-      return SendSmsAsync(phone, text, null, out error, method);
+      return SendSmsAsync(phone, text, null, out error, method, isInElection);
     }
 
     public bool SendVerifyCodeToVoterByPhone(string phone, string newCode, string hubKey, out string error)
@@ -236,7 +236,7 @@ namespace TallyJ.CoreModels.Helper
           p.VoterContact,
         });
 
-        var ok = SendSmsAsync(phoneNumber, messageText, p.PersonGuid, out var errorMessage);
+        var ok = SendSmsAsync(phoneNumber, messageText, p.PersonGuid, out var errorMessage, "sms", true);
 
         if (ok)
           numSent++;
@@ -280,7 +280,7 @@ namespace TallyJ.CoreModels.Helper
     /// <param name="errorMessage"></param>
     /// <param name="method">sms or whatsapp</param>
     /// <returns></returns>
-    public bool SendSmsAsync(string toPhoneNumber, string messageText, Guid? personGuid, out string errorMessage, string method = "sms")
+    public bool SendSmsAsync(string toPhoneNumber, string messageText, Guid? personGuid, out string errorMessage, string method = "sms", bool isInElection = false)
     {
       var sid = SettingsHelper.Get("twilio-SID", "");
       var token = SettingsHelper.Get("twilio-Token", "");
@@ -319,19 +319,22 @@ namespace TallyJ.CoreModels.Helper
 
       TwilioClient.Init(sid, token);
 
-      // add to the safelist (ignore if already there)
-      try
+      if (isInElection)
       {
-        var safelistNumber = SafelistResource.Create(toPhoneNumber);
-        Console.WriteLine($"Added: {safelistNumber.PhoneNumber} (SID: {safelistNumber.Sid})");
-      }
-      catch (ApiException ex) when (ex.Code == 60411)
-      {
-        Console.WriteLine($"Already on the safe list: {toPhoneNumber}");
-      }
-      catch (Exception ex)
-      {
-        new LogHelper().Add("SMS Add to SafeList failed - {0} ({1})".FilledWith(ex.Message, toPhoneNumber), true);
+        // add to the safelist (ignore if already there), but only if known to be in an election
+        try
+        {
+          var safelistNumber = SafelistResource.Create(toPhoneNumber);
+          Console.WriteLine($"Added: {safelistNumber.PhoneNumber} (SID: {safelistNumber.Sid})");
+        }
+        catch (ApiException ex) when (ex.Code == 60411)
+        {
+          Console.WriteLine($"Already on the safe list: {toPhoneNumber}");
+        }
+        catch (Exception ex)
+        {
+          new LogHelper().Add("SMS Add to SafeList failed - {0} ({1})".FilledWith(ex.Message, toPhoneNumber), true);
+        }
       }
 
       try

--- a/Site/CoreModels/Helper/VoterCodeHelper.cs
+++ b/Site/CoreModels/Helper/VoterCodeHelper.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Web;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
+using Newtonsoft.Json;
 using TallyJ.Code;
 using TallyJ.Code.Enumerations;
 using TallyJ.Code.Resources;
@@ -89,7 +90,7 @@ namespace TallyJ.CoreModels.Helper
         };
 
       var newCode = MakeCode();
-      CreateOrUpdateOnlineVoter(voterIdType, target, newCode, out message);
+      var isInElection = CreateOrUpdateOnlineVoter(voterIdType, target, newCode, out message);
       if (message.HasContent())
         return new
         {
@@ -111,7 +112,7 @@ namespace TallyJ.CoreModels.Helper
       }
       else if (voterIdType == VoterIdTypeEnum.Phone)
       {
-        sent = SendViaTwilio(target, method, newCode, out message);
+        sent = SendViaTwilio(target, method, newCode, isInElection, out message);
 
         if (message.HasContent())
         {
@@ -140,13 +141,33 @@ namespace TallyJ.CoreModels.Helper
       };
     }
 
-
-    private void CreateOrUpdateOnlineVoter(VoterIdTypeEnum voterIdType, string voterId, string newCode, out string errorMessage, bool reset = false)
+    /// <summary>
+    ///  Create or update the OnlineVoter record with the new code
+    /// </summary>
+    /// <param name="voterIdType"></param>
+    /// <param name="voterId"></param>
+    /// <param name="newCode"></param>
+    /// <param name="errorMessage"></param>
+    /// <param name="reset"></param>
+    /// <returns>True if this Email or Phone is found in an election. (Ignore for Kiosk mode)</returns>
+    private bool CreateOrUpdateOnlineVoter(VoterIdTypeEnum voterIdType, string voterId, string newCode, out string errorMessage, bool reset = false)
     {
       // find or make this OnlineVoter record
       var db = UserSession.GetNewDbContext;
       var onlineVoter = db.OnlineVoter.FirstOrDefault(ov => ov.VoterIdType == voterIdType && ov.VoterId == voterId);
       var utcNow = DateTime.UtcNow;
+
+      // determine how many elections this voterId is used in
+      var numElections =
+        voterIdType == VoterIdTypeEnum.Phone ?
+           db.Person
+            .Where(p => p.Phone == voterId)
+            .Count() :
+        voterIdType == VoterIdTypeEnum.Email ?
+          db.Person
+            .Where(p => p.Email == voterId)
+            .Count() : 0;
+      // don't bother for kiosk - it should always be 1, so don't calculate it and store it as 0.
 
       if (onlineVoter == null)
       {
@@ -158,12 +179,32 @@ namespace TallyJ.CoreModels.Helper
           VerifyCodeDate = utcNow,
           VerifyAttempts = 1,
           VerifyAttemptsStart = utcNow,
-          WhenRegistered = utcNow
+          WhenRegistered = utcNow,
+          OtherInfo = JsonConvert.SerializeObject( new OnlineVoterOtherInfo { NumElections = numElections })
         };
         db.OnlineVoter.Add(onlineVoter);
       }
       else
       {
+        // use the JSON structure, incase it is extended in the future
+        var json = onlineVoter.OtherInfo;
+        OnlineVoterOtherInfo otherInfo;
+        try
+        {
+          otherInfo = string.IsNullOrWhiteSpace(json)
+              ? new OnlineVoterOtherInfo()
+              : JsonConvert.DeserializeObject<OnlineVoterOtherInfo>(json) ?? new OnlineVoterOtherInfo();
+        }
+        catch (JsonException)
+        {
+          // Handle invalid JSON gracefully
+          otherInfo = new OnlineVoterOtherInfo();
+        }
+
+        otherInfo.NumElections = numElections;
+
+        onlineVoter.OtherInfo = JsonConvert.SerializeObject(otherInfo);
+
         var verifyAttemptsStart = onlineVoter.VerifyAttemptsStart.AsUtc();
         var attempts = onlineVoter.VerifyAttempts.GetValueOrDefault();
 
@@ -178,7 +219,7 @@ namespace TallyJ.CoreModels.Helper
         if (attempts >= UserAttemptMax)
         {
           errorMessage = "Too many attempts. Please wait before trying again.";
-          return;
+          return numElections > 0;
         }
 
         //TODO - ensure not being hit too often
@@ -192,6 +233,8 @@ namespace TallyJ.CoreModels.Helper
       db.SaveChanges();
 
       errorMessage = "";
+
+      return numElections > 0;
     }
 
     private void CheckSiteUsageThresholds(out string message)
@@ -251,7 +294,7 @@ namespace TallyJ.CoreModels.Helper
       message = "";
     }
 
-    private bool SendViaTwilio(string phoneNumber, string method, string newCode, out string message)
+    private bool SendViaTwilio(string phoneNumber, string method, string newCode, bool isInElection, out string message)
     {
       UserSession.TwilioMsgId = null;
       var twilioHelper = new TwilioHelper();
@@ -260,14 +303,14 @@ namespace TallyJ.CoreModels.Helper
       {
         case "sms":
         case "whatsapp":
-          twilioHelper.SendVerifyCodeToVoter(phoneNumber, newCode, method, _hubKey, out message);
+          twilioHelper.SendVerifyCodeToVoter(phoneNumber, newCode, method, _hubKey, isInElection, out message);
           if (message.HasNoContent()) MonitorSmsStatus(twilioHelper);
           break;
 
         case "voice":
+          // don't bother with isInElection for voice calls
           twilioHelper.SendVerifyCodeToVoterByPhone(phoneNumber, newCode, _hubKey, out message);
           if (message.HasNoContent()) MonitorCallStatus(twilioHelper);
-
           break;
 
         default:

--- a/Site/Site.csproj
+++ b/Site/Site.csproj
@@ -479,6 +479,7 @@
     <Compile Include="CoreModels\Helper\EncryptionHelper.cs" />
     <Compile Include="CoreModels\Helper\NotificationHelper.cs" />
     <Compile Include="CoreModels\Helper\MessageHelperBase.cs" />
+    <Compile Include="CoreModels\Helper\OnlineVoterOtherInfo.cs" />
     <Compile Include="CoreModels\Helper\TwilioHelper.cs" />
     <Compile Include="CoreModels\Helper\SmsOtherInfo.cs" />
     <Compile Include="CoreModels\Helper\VoterCodeHelper.cs" />

--- a/Site/web.config
+++ b/Site/web.config
@@ -16,10 +16,10 @@
   <applicationSettings>
     <TallyJ.Properties.Settings>
       <setting name="VersionNum" serializeAs="String"> 
-        <value>3.5.41</value>
+        <value>3.5.42</value>
       </setting>
       <setting name="VersionDate" serializeAs="String"> 
-        <value>5 December 2025 / 15 Speech 182</value>
+        <value>3 January 2026 / 5 Honor 182</value>
       </setting>
     </TallyJ.Properties.Settings>
   </applicationSettings>


### PR DESCRIPTION
- Added `bool isInElection` parameter to several methods in `TwilioHelper` to manage SMS sending based on election context.
- Updated `SendSmsAsync` to conditionally add phone numbers to the safelist.
- Modified `CreateOrUpdateOnlineVoter` to return a boolean indicating election association.
- Adjusted `SendViaTwilio` to pass the new `isInElection` parameter.
- Introduced `OnlineVoterOtherInfo` class to store additional voter information.
- Updated project version in `web.config` from `3.5.41` to `3.5.42`.
- Included `OnlineVoterOtherInfo.cs` in the project compilation.